### PR TITLE
fix build image name

### DIFF
--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -17,7 +17,7 @@
 USERNAME=usdotfhwastol
 
 cd "$(dirname "$0")"
-IMAGE=$(./get-package-name.sh | tr '[:upper:]' '[:lower:]')
+IMAGE=$(./get-image-name.sh | tr '[:upper:]' '[:lower:]')
 
 echo ""
 echo "##### $IMAGE Docker Image Build Script #####"


### PR DESCRIPTION
Fix for https://github.com/usdot-fhwa-stol/CARMAPlatform/issues/482 

Updated build-image.sh to use the ./get-image-name.sh, instead of get-package-name.sh. All other repose are using get-image-name.sh. 

